### PR TITLE
Add data science (offensiveness, toxicity) endpoints for post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 /supabase/gitignore
 
 /utils/scripts/data_generator_util
+.vscode

--- a/components/liveFeed/hooks/useCreatePost.ts
+++ b/components/liveFeed/hooks/useCreatePost.ts
@@ -39,24 +39,57 @@ const useLiveFeed = ({ refetch }: Props) => {
         console.log('error', error);
       },
     });
+
+    const handlePostToxicity = useMutation({
+      mutationFn: async (postData: { text: string }) => {
+        const response = await axios.post<{
+          label: string;
+        }>('https://api.one-accord.xyz/api/predict_toxicity', { text: postData.text });
+        return response.data;
+      },
+      onError: (error) => {
+        console.log('Error while determining toxicity:', error);
+      },
+    });
+
+    const handlePostOffensiveness = useMutation({
+      mutationFn: async (postData: { text: string }) => {
+        const response = await axios.post<{
+          predictions: [{label: string}];
+        }>('https://api.one-accord.xyz/api/predict_offensiveness', { text: postData.text });
+        return response.data;
+      },
+      onError: (error) => {
+        console.log('Error while determining offensiveness:', error);
+      },
+    });
+    
   
     const onValid = async (data: CreteContentPostSchemaType) => {
       console.log("🚀 ~ onValid ~ data:", data);
-    
-      // Build object for post
-      const postData: CretePostSchemaType = {
-        user_id: '94b2a736-d8c7-4722-8d64-86a0a24d4f80', 
-        activity_id: '6e6a36da-06ed-426d-80cc-d1ff2276fb98',
-        category_id: '2525edcc-b972-4a14-bfc5-66697a89b5bc',
-        content: data.content || '', // Ensure that content has a value
-        created_at: new Date().toISOString(),
-        event_id: '9eac149d-12b1-4c91-b14b-8fd87341b572',
-        is_offensive: false,
-        is_visible: true,
-        keywords_id: 'b5901b2c-b39b-4b20-8465-0b7898b159e9',
-        media_type_id: 'f1075159-b937-4e9c-a5f1-2aa2d482086e',
-        sentiment_id: '94ddc4f2-82f7-4c22-8e56-95b462d3b7ae',
-      };
+      const { label: postToxicity } = await handlePostToxicity.mutateAsync({ text: data.content });
+      const isToxic = postToxicity === 'toxic';
+
+      const { predictions: postOffensiveness } = await handlePostOffensiveness.mutateAsync({ text: data.content });
+      console.log("🚀 ~ onValid ~ postOffensiveness:", postOffensiveness)
+      const isOffensive = postOffensiveness[0].label === 'offensive';
+
+    // Build object for post
+    const postData: CretePostSchemaType = {
+      user_id: '94b2a736-d8c7-4722-8d64-86a0a24d4f80', 
+      activity_id: '6e6a36da-06ed-426d-80cc-d1ff2276fb98',
+      category_id: '2525edcc-b972-4a14-bfc5-66697a89b5bc',
+      content: data.content || '', // Ensure that content has a value
+      created_at: new Date().toISOString(),
+      event_id: '9eac149d-12b1-4c91-b14b-8fd87341b572',
+      // is_toxic: isToxic
+      is_offensive: isOffensive,
+      is_visible: true,
+      keywords_id: 'b5901b2c-b39b-4b20-8465-0b7898b159e9',
+      media_type_id: 'f1075159-b937-4e9c-a5f1-2aa2d482086e',
+      sentiment_id: '94ddc4f2-82f7-4c22-8e56-95b462d3b7ae',
+    };
+    console.log("🚀 ~ onValid ~ postData:", postData)
     
       // Validation of required fields
       if (!postData.user_id || !postData.activity_id || !postData.category_id || !postData.sentiment_id || !postData.keywords_id || !postData.event_id || !postData.media_type_id) {
@@ -66,7 +99,6 @@ const useLiveFeed = ({ refetch }: Props) => {
     
       // Schema validation with zod
       const parsedValues = CretePostSchema.safeParse(postData);
-      console.log("🚀 ~ onValid ~ parsedValues:", parsedValues);
     
       if (!parsedValues.success) {
         type K = keyof CreteContentPostSchemaType;


### PR DESCRIPTION
Implemented data science endpoints for evaluating the offensiveness and toxicity of posts. This enhancement introduces two functions, handlePostToxicity and handlePostOffensiveness, designed to interact with and process data from the respective endpoints. These functions enable seamless integration of toxicity and offensiveness analysis into the platform's post handling workflow, enhancing content moderation capabilities.
